### PR TITLE
Fix #235: Update in Maestro provider to correctly parse for large integers in response

### DIFF
--- a/src/provider/maestro.ts
+++ b/src/provider/maestro.ts
@@ -109,7 +109,9 @@ export class Maestro implements Provider {
     });
     const result: MaestroUtxos = await this.getAllPagesData(
       async (qry: string) =>
-        await fetch(qry, { headers: this.commonHeaders() }),
+        await fetch(qry, {
+          headers: this.requireAmountsAsStrings(this.commonHeaders()),
+        }),
       `${this.url}${queryPredicate}/utxos`,
       qparams,
       "Location: getUtxosInternal. Error: Could not fetch UTxOs from Maestro",
@@ -177,7 +179,7 @@ export class Maestro implements Provider {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            ...this.commonHeaders(),
+            ...(this.requireAmountsAsStrings(this.commonHeaders())),
           },
           body: body,
         }),
@@ -206,7 +208,7 @@ export class Maestro implements Provider {
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
     const timestampedResultResponse = await fetch(
-      `${this.url}/datum/${datumHash}`,
+      `${this.url}/datums/${datumHash}`,
       {
         headers: this.commonHeaders(),
       },
@@ -269,6 +271,10 @@ export class Maestro implements Provider {
 
   private commonHeaders() {
     return { "api-key": this.apiKey, lucid };
+  }
+
+  private requireAmountsAsStrings(obj: { "api-key": string; lucid: string }) {
+    return { ...obj, "amounts-as-strings": "true" };
   }
 
   private maestroUtxoToUtxo(result: MaestroUtxo): UTxO {
@@ -344,7 +350,7 @@ type MaestroScript = {
 
 type MaestroAsset = {
   unit: string;
-  amount: number;
+  amount: string;
 };
 
 type MaestroUtxo = {


### PR DESCRIPTION
Tokens in Cardano [could be minted with amounts as large as](https://github.com/input-output-hk/cardano-ledger/blob/1684482184814e5f830da506ab54bec619174a12/eras/babbage/impl/cddl-files/babbage.cddl#L406-L408) $2^{63} - 1$ (maximum of what signed 64 bit can support) which is larger than what could be safely represented for in JS. Standard JSON parser for JS would not be making use of `bigint`, consequently, this PR makes use of `amounts-as-strings` header attribute when making request to get amounts as `string`s instead, to cast later as `bigint`.

Closes #235.